### PR TITLE
Add Sphinx docstrings and legacy compatibility helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,101 +14,123 @@ it is best to install from Github using ``pip``:
 
 ## Usage
 
-``windwhisper`` can be used to estimate the noise propagation from wind turbines. 
-The following example shows how to estimate the noise propagation from a series of
-wind turbines, and the exposure of a number of listeners to noise, expressed using
-the L_den indicator. Results can be exported on a map.
+``windwhisper`` can be used to estimate the noise propagation from wind turbines and
+to assess combined ambient noise levels around a project area. The quick-start example
+below walks through the typical workflow and highlights which inputs you need to
+provide at each step.
 
+### Package structure at a glance
 
-### Initializing wind turbines and listeners:
+* ``windturbines`` – validates turbine specifications, trains or loads an acoustic
+  emission model, and predicts sound power levels for 3–12 m/s wind speeds.
+* ``windspeed`` – loads ERA5-based mean wind speeds, optionally applies correction
+  factors, or falls back to the NEWA API when local files are missing.
+* ``noisepropagation`` – computes propagation losses (distance, atmospheric,
+  ground, obstacles), derives hourly levels, and aggregates to L_den and L_night.
+* ``ambient_noise`` – fetches EU environmental noise rasters and combines them with
+  modelled turbine levels.
+* ``noiseanalysis`` – merges turbine and ambient layers, exports interactive maps,
+  and prepares GeoJSON contour data.
+* ``health_impacts`` – estimates population exposure, DALYs, and energy outputs for
+  health assessments.
+
+Additional utilities cover terrain handling (``ground_attenuation``), atmospheric
+absorption, plotting helpers, and settlement/population data preparation.
+
+### Required inputs and configuration
+
+| Step | Mandatory inputs | Optional inputs & configuration |
+| ---- | ---------------- | -------------------------------- |
+| ``WindTurbines`` | Dictionary of turbines with ``power`` (kW), ``diameter`` (m), ``hub height`` (m), and ``position`` (latitude, longitude). | ``retrain_model``/``dataset_file`` to fit a custom noise model; pre-loaded ``wind_speed_data`` as an ``xarray.DataArray``. |
+| ``WindSpeed`` | – (auto-loads packaged ERA5 climatology). | ``wind_speed_data`` array to bypass file/API loading; NEWA API key via ``API_NEWA`` env var for live downloads. |
+| ``NoisePropagation`` | Output from ``WindTurbines`` including ``noise_vs_wind_speed`` and ``mean_wind_speed``. | Relative humidity/temperature, local ``elevation_data`` (``xarray.Dataset``). When omitted, terrain data must be retrievable through the configured elevation service (requires API token in ``secret.json`` as referenced in code comments). |
+| ``NoiseAnalysis`` | ``NoisePropagation`` instance. | EU Noise API endpoints via environment variables (``API_EU_NOISE_*``) to obtain ambient rasters. |
+| Mapping/health | – | Optional: custom output filepath, DALY parameters, Google elevation API token, etc. |
+
+Ensure the relevant API keys are available in your environment (e.g., ``API_NEWA``)
+or configuration files before running a simulation.
+
+### End-to-end example
+
+The snippet below configures a single turbine, runs the propagation model,
+exports mapping artefacts, and quantifies the human-health impacts over the
+project lifetime.
 
 ```python
+import xarray as xr
 
-    from windwhisper import WindTurbines, NoisePropagation, NoiseAnalysis
-    import xarray as xr
-    
-    # we can preload the wind speed data, otherwise, the tool will do it every time
-    # if you do not have wind data, the tool will fetch data from the New Wind Atlas API instead
-    
-    filepath_wind_speed = "/Users/romain/GitHub/windwhisper/dev/fixtures/era5_mean_2013-2022_month_by_hour.nc"
-    filepath_correction = "/Users/romain/GitHub/windwhisper/dev/fixtures/ratio_gwa2_era5.nc"
-    
-    def wind_speed_data():
-    
-        wind_speed = xr.open_dataset(filepath_wind_speed).to_array().mean(dim="month")
-        correction = xr.open_dataset(filepath_correction).to_array()
-        correction = correction.sel(variable='ratio_gwa2_era5_mean_WS').interp(latitude=wind_speed.latitude, longitude=wind_speed.longitude, method="linear")
-        return wind_speed * correction
-    
-    wind_speed_data = wind_speed_data()
-    
-    wind_turbines = {
-        'Turbine 0':
-         {
-            'diameter': 70.0,
-            'hub height': 85.0,
-            'position': (43.45111343125036, 5.2518247370645215),
-            'power': 2500.0
-         },
+from windwhisper import (
+    DATA_DIR,
+    WindTurbines,
+    NoisePropagation,
+    NoiseAnalysis,
+    HumanHealth,
+)
+
+
+# 1. Describe your turbines (power in kW, geometry in metres, WGS84 coordinates)
+wind_turbines = {
+    "Demo turbine": {
+        "power": 2_500,
+        "diameter": 70,
+        "hub height": 85,
+        "position": (43.4511, 5.2518),
     }
-    
-    wt = WindTurbines(
-        wind_turbines=wind_turbines,
-        wind_speed_data=wind_speed_data,
-        #retrain_model=True
+}
+
+# 2. (Optional) load wind-speed climatology once and reuse it
+fixtures = DATA_DIR.parent / "dev" / "fixtures"
+wind_speed_file = fixtures / "era5_mean_2013-2022_month_by_hour.nc"
+correction_file = fixtures / "ratio_gwa2_era5.nc"
+
+if wind_speed_file.exists() and correction_file.exists():
+    wind_speed = xr.open_dataset(wind_speed_file).to_array().mean(dim="month")
+    correction = xr.open_dataset(correction_file).to_array()
+    correction = correction.sel(
+        variable="ratio_gwa2_era5_mean_WS"
+    ).interp(
+        latitude=wind_speed.latitude,
+        longitude=wind_speed.longitude,
+        method="linear",
     )
-    
-    # Noise propagation calculation
-    # you can provide local elevation data
-    # if not, the tool will fetch data from the Google Maps API 
-    # (you need to provide an API token in a secret.json file in teh root folder)
-    elevation_data = xr.open_dataset("fixtures/Copernicus_DSM_90m_COG.nc")
+    wind_speed = wind_speed * correction
+else:
+    wind_speed = None  # WindSpeed will fall back to the configured API
 
-    noise_prop = NoisePropagation(
-        wind_turbines=wt.wind_turbines,
-        humidity=70,
-        temperature=20,
-        elevation_data=elevation_data,
-    )
-    
-    # Noise analysis
-    noise_analysis = NoiseAnalysis(
-        noise_propagation=noise_prop,
-        wind_turbines=wt.wind_turbines,
-    )
+wt = WindTurbines(
+    wind_turbines=wind_turbines,
+    wind_speed_data=wind_speed,
+)
 
+# 3. Provide site conditions; use your own elevation raster when available
+elevation_path = fixtures / "Copernicus_DSM_90m_COG.nc"
+elevation = xr.open_dataset(elevation_path) if elevation_path.exists() else None
 
-```
+noise_prop = NoisePropagation(
+    wind_turbines=wt.wind_turbines,
+    humidity=70,
+    temperature=20,
+    elevation_data=elevation,
+)
 
+# 4. Merge with ambient sources, create maps, and export contours
+noise_analysis = NoiseAnalysis(
+    noise_propagation=noise_prop,
+    wind_turbines=wt.wind_turbines,
+)
+noise_analysis.generate_map(filepath="my_noise_map.html")
+ambient, wind, combined, net, flip = noise_analysis.get_geojson_contours()
 
-### Noise Map Generation
+# 5. Quantify health impacts over the turbines' lifetime
+human_health = HumanHealth(
+    noise_analysis=noise_analysis,
+    lifetime=25,  # optional (defaults to 20 years)
+)
 
-An HTML map can exported, with noise contours for different L_den noise levels (in dB(A)).
+print(f"Total DALYs: {human_health.human_health:.2e}")
+print(f"DALYs per kWh: {human_health.human_health_per_kWh:.2e}")
 
-```python
-
-    noise_analysis.generate_map(
-        filepath="my_noise_map.html"
-    )
-
-```
-
-### GeoJSON export
-
-Alternatively, GeoJSON objects from contours can be produced from the raster data.
-`.get_geojson_contours()? fetches geoJson L_den noise contour objects for:
-
-* ambient noise sources (from the EU Noise maps, including industry, road, rail, and air traffic)
-* noise from the wind turbines, 
-* combined ambient and wind turbines' noise
-* net wind turbines noise contribution
-* and noise levels above EU guidelines (i.e., 55 dB(A)) as a result of the wind turbines implementation.
-
-
-```python
-    
-    noise_analysis.get_geojson_contours()
-
+human_health.export_to_excel("human_health_summary.xlsx")
 ```
 
 ## License

--- a/windwhisper/atmospheric_absorption.py
+++ b/windwhisper/atmospheric_absorption.py
@@ -7,8 +7,11 @@ import yaml
 
 
 def load_atmospheric_absorption_coefficients():
-    """
-    Load YAML file containing the atmospheric absorption coefficients.
+    """Load atmospheric absorption coefficients from disk.
+
+    :returns: Nested mapping keyed by temperature and relative humidity with
+        absorption coefficients per frequency band.
+    :rtype: dict
     """
 
     with open(DATA_DIR / "absorption_coefficients.yaml") as file:
@@ -16,11 +19,13 @@ def load_atmospheric_absorption_coefficients():
 
 
 def compute_weighted_absorption(absorption_coefficients):
-    """
-    Compute the weighted absorption coefficient directly using spectral levels in dB.
+    """Compute a weighted atmospheric absorption coefficient.
 
-    :param absorption_coefficients: Dictionary of absorption coefficients (dB/km) by frequency band (Hz).
-    :return: Weighted absorption coefficient (alpha_weighted) in dB/km.
+    :param absorption_coefficients: Absorption coefficients in dB/km keyed by
+        third-octave band centre frequency.
+    :type absorption_coefficients: dict[str, float]
+    :returns: Weighted absorption coefficient in dB/km.
+    :rtype: float
     """
     # Third-octave bands and their A-weighting corrections
     frequencies = list(absorption_coefficients.keys())
@@ -54,15 +59,16 @@ def compute_weighted_absorption(absorption_coefficients):
 
 
 def get_absorption_coefficient(temperature=20, humidity=70):
-    """
-    Get the atmospheric absorption coefficient for a given noise level, temperature, and humidity.
+    """Return the weighted absorption coefficient for the given conditions.
 
-    :param temperature: The temperature in degrees Celsius. Default is 20.
+    :param temperature: Air temperature in degrees Celsius.
     :type temperature: float
-    :param humidity: The relative humidity in percent. Default is 70.
+    :param humidity: Relative humidity expressed as a percentage.
     :type humidity: float
-    :return: The atmospheric absorption coefficient, in dB/km.
-
+    :returns: Weighted absorption coefficient in dB/km.
+    :rtype: float
+    :raises ValueError: If the requested temperature or humidity is not
+        available in the coefficient table.
     """
 
     # Load the atmospheric absorption coefficients

--- a/windwhisper/electricity_production.py
+++ b/windwhisper/electricity_production.py
@@ -3,15 +3,14 @@ import xarray as xr
 from . import DATA_DIR
 
 def get_capacity_factor(lat, lon):
-    """
-    Fetch capacity factor data for a given latitude and longitude.
+    """Interpolate the GWA3 capacity factor at a given location.
 
-    Parameters:
-        lat (float): Latitude in degrees.
-        lon (float): Longitude in degrees.
-
-    Returns:
-        xarray.DataArray: Capacity factor at the specified location.
+    :param lat: Latitude in degrees.
+    :type lat: float
+    :param lon: Longitude in degrees.
+    :type lon: float
+    :returns: Capacity factor for the requested coordinates.
+    :rtype: float
     """
     filepath = DATA_DIR / "gwa3_capacityfactor_latlon.nc"
     ds = xr.open_dataset(filepath)
@@ -21,14 +20,18 @@ def get_capacity_factor(lat, lon):
     return cf
 
 def get_electricity_production(lat: float, lon: float, power: int, lifetime: int):
-    """
-    Fetch electricity production data for a given latitude and longitude.
+    """Estimate the lifetime electricity production for a wind turbine.
 
     :param lat: Latitude in degrees.
+    :type lat: float
     :param lon: Longitude in degrees.
+    :type lon: float
     :param power: Rated power of the wind turbine in kW.
-    :param lifetime: Lifetime of the wind turbine in years.
-    :return: Electricity production in kWh over the lifetime.
+    :type power: int
+    :param lifetime: Operational lifetime in years.
+    :type lifetime: int
+    :returns: Energy yield in kWh produced over the lifetime.
+    :rtype: float
     """
     capacity_factor = get_capacity_factor(lat, lon)
     down_time = 0.05  # Example downtime percentage

--- a/windwhisper/geometric_divergence.py
+++ b/windwhisper/geometric_divergence.py
@@ -6,10 +6,11 @@ import numpy as np
 
 
 def get_geometric_spread_loss(distance: np.array) -> np.array:
-    """
-    Calculate the geometric spread loss in dB, according to ISO 9613-2:2024.
-    :param distance: The distance between the source and receiver in meters.
-    :return: The geometric spread loss
+    """Calculate the geometric spread loss in accordance with ISO 9613-2:2024.
 
+    :param distance: Distance between source and receiver in metres.
+    :type distance: numpy.ndarray | float
+    :returns: Geometric divergence loss in dB.
+    :rtype: numpy.ndarray | float
     """
     return 20 * np.log10(distance / 1) + 11

--- a/windwhisper/plotting.py
+++ b/windwhisper/plotting.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 import folium
 from folium import Map, Element
 import geojson
+import numpy as np
 from shapely.geometry import LineString, mapping, Polygon
 
 color_map = {
@@ -17,8 +18,16 @@ color_map = {
 
 
 def generate_contours(data, levels, name="Noise Contours"):
-    """
-    Generate contours using Matplotlib and create a GeoJSON object for Folium.
+    """Generate contour polygons and wrap them into a Folium layer.
+
+    :param data: Raster to contour.
+    :type data: xarray.DataArray
+    :param levels: Contour levels in dB.
+    :type levels: list[int]
+    :param name: Name of the resulting Folium layer.
+    :type name: str
+    :returns: Folium feature group containing contour polylines.
+    :rtype: folium.FeatureGroup
     """
 
     # Generate the contours
@@ -79,11 +88,12 @@ def generate_contours(data, levels, name="Noise Contours"):
 
 
 def add_legend(map_object):
-    """
-    Adds a legend to the Folium map.
+    """Append a categorical legend to a Folium map.
 
-    :param map_object: The Folium map object to add the legend to.
-    :param color_map: A dictionary mapping contour levels to colors.
+    :param map_object: Folium map receiving the legend.
+    :type map_object: folium.Map
+    :returns: The modified map object.
+    :rtype: folium.Map
     """
     legend_html = """
     <div style="
@@ -108,14 +118,16 @@ def add_legend(map_object):
     return map_object
 
 def rotate_coordinates(coords, angle, center):
-    """
-    Rotate a list of coordinates by a given angle around a center point.
-    Args:
-        coords (list of tuples): List of (latitude, longitude) coordinates.
-        angle (float): Rotation angle in degrees.
-        center (tuple): Center of rotation as (latitude, longitude).
-    Returns:
-        list of tuples: Rotated coordinates.
+    """Rotate coordinates around a centroid.
+
+    :param coords: Sequence of ``(latitude, longitude)`` pairs.
+    :type coords: list[tuple[float, float]]
+    :param angle: Rotation angle in degrees.
+    :type angle: float
+    :param center: Rotation centre expressed as ``(latitude, longitude)``.
+    :type center: tuple[float, float]
+    :returns: Rotated coordinates as ``(latitude, longitude)`` pairs.
+    :rtype: list[tuple[float, float]]
     """
     angle_rad = np.radians(angle)
     center_x, center_y = center
@@ -141,6 +153,15 @@ def generate_map(
         noise_dataset,
         filepath="noise_map.html"
 ):
+    """Export contour overlays for the provided noise dataset.
+
+    :param noise_dataset: Dataset containing combined noise layers.
+    :type noise_dataset: xarray.Dataset
+    :param filepath: Destination filepath for the generated HTML map.
+    :type filepath: str
+    :returns: Generated Folium map instance.
+    :rtype: folium.Map
+    """
 
     # Create Folium map
     center_lat = np.mean(noise_dataset.lat.values)
@@ -204,9 +225,17 @@ def generate_map(
 
     # Save the map as an HTML file
     m.save(filepath)
+    return m
 
 
 def create_geojson(data):
+    """Generate a GeoJSON feature collection of contour polylines.
+
+    :param data: Raster to contour.
+    :type data: xarray.DataArray
+    :returns: GeoJSON feature collection describing the contour lines.
+    :rtype: geojson.FeatureCollection
+    """
 
     color_map = {
         30: "green",

--- a/windwhisper/settlement.py
+++ b/windwhisper/settlement.py
@@ -9,14 +9,12 @@ import xarray as xr
 
 
 def get_population_subset(bbox: box):
-    """
-    Fast version for EPSG:4326 (lat/lon) NetCDF: slices lat/lon bounding box directly.
+    """Extract population data within the requested bounding box.
 
-    Parameters:
-        lat_min, lat_max, lon_min, lon_max (float): Bounding box in degrees
-
-    Returns:
-        xarray.DataArray: Subset of population data within the bounding box
+    :param bbox: Bounding box in geographic coordinates (EPSG:4326).
+    :type bbox: shapely.geometry.Polygon
+    :returns: Population raster subset covering the bounding box.
+    :rtype: xarray.DataArray
     """
 
     lon_min, lat_min, lon_max, lat_max = bbox.bounds

--- a/windwhisper/utils.py
+++ b/windwhisper/utils.py
@@ -4,16 +4,16 @@ import json
 from . import HOME_DIR
 
 def create_bounding_box(center_x: float, center_y: float, buffer_meters: int) -> tuple:
-    """
-    Creates a bounding box around a center point with a specified buffer.
+    """Create a square bounding box around a point.
 
-    Parameters:
-        center_x (float): X coordinate of the center point.
-        center_y (float): Y coordinate of the center point.
-        buffer_meters (float): Buffer distance in meters.
-
-    Returns:
-        tuple: Bounding box as (min_x, min_y, max_x, max_y).
+    :param center_x: X coordinate of the centre.
+    :type center_x: float
+    :param center_y: Y coordinate of the centre.
+    :type center_y: float
+    :param buffer_meters: Distance applied in all directions.
+    :type buffer_meters: float
+    :returns: Bounding box ``(min_x, min_y, max_x, max_y)``.
+    :rtype: tuple[float, float, float, float]
     """
     min_x = center_x - buffer_meters
     max_x = center_x + buffer_meters
@@ -24,16 +24,31 @@ def create_bounding_box(center_x: float, center_y: float, buffer_meters: int) ->
 
 
 def translate_4326_to_3035(lon: float, lat: float) -> tuple:
-    # Initialize the transformer for EPSG:4326 to EPSG:3035
+    """Project geographic coordinates to the European LAEA CRS.
+
+    :param lon: Longitude in degrees.
+    :type lon: float
+    :param lat: Latitude in degrees.
+    :type lat: float
+    :returns: Projected ``(x, y)`` coordinates in metres.
+    :rtype: tuple[float, float]
+    """
+
     transformer = Transformer.from_crs("EPSG:4326", "EPSG:3035", always_xy=True)
 
     return transformer.transform(lon, lat)
 
 
 def load_secret():
+    """Load the Google API key from the project secret file.
+
+    :returns: API key string when available, otherwise ``None``.
+    :rtype: str | None
+    """
+
     try:
         with open(f"{HOME_DIR}/secret.json") as f:
             data = json.load(f)
             return data["google_api_key"]
-    except Exception as e:
+    except Exception:
         return None


### PR DESCRIPTION
## Summary
- add Sphinx-style docstrings across ambient noise, wind turbine, wind speed, and analysis modules to document parameters and return values
- introduce backward-compatible helpers in NoisePropagation and NoiseAnalysis to support older APIs used by tests
- update utility modules with clearer module descriptions and fallback behaviour for missing datasets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690881ea84bc8333a2c57b629559a163